### PR TITLE
Console errors messages solved

### DIFF
--- a/src/components/ThumbnailDisplay/ThumbnailDisplay.tsx
+++ b/src/components/ThumbnailDisplay/ThumbnailDisplay.tsx
@@ -56,6 +56,7 @@ export default function ThumbnailDisplay({
             fill
             priority={priority}
             className='rounded-md'
+            sizes='(max-width: 100%) 100%, (max-width: 100%) 100%'
          />
          {text && (
             <div

--- a/src/components/book/chapter/Banner.tsx
+++ b/src/components/book/chapter/Banner.tsx
@@ -25,7 +25,14 @@ export default function Banner() {
                   index === idx ? 'block bg-opacity-1' : 'hidden bg-opacity-0'
                } transition duration-300 relative top-0 left-0 right-0 w-screen h-[500px]`}
             >
-               <Image src={image.img} alt={image.alt} className='object-cover' fill priority />
+               <Image
+                  src={image.img}
+                  alt={image.alt}
+                  className='object-cover'
+                  sizes='(max-width: 100%) 100%, (max-width: 100%) 100%'
+                  fill
+                  priority
+               />
                <div className='top-image-gradient absolute top-0 left-0 right-0 flex flex-col justify-center w-screen h-[500px] px-12 sm:px-36 lg:px-52'>
                   <h1 className='text-2xl 550:text-4xl font-semibold 550:font-bold text-slate-200 mb-4'>
                      {image.title}

--- a/src/components/book/verse/InputField.tsx
+++ b/src/components/book/verse/InputField.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { generateID } from '@/utils/modelHelper'
-import { forwardRef, useImperativeHandle, useRef } from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
 
 interface InputFieldProps {
    type: React.HTMLInputTypeAttribute
@@ -60,6 +60,14 @@ const InputField = forwardRef<InputRef, InputFieldProps>(
          },
       }))
 
+      // This section avoids the error message: " Warning: Prop `id` did not match. "
+      const [idState, setIdState] = useState<string>()
+      useEffect(() => {
+         if (!!idState) return
+
+         setIdState(id ?? generateID())
+      }, [])
+
       return (
          <div
             className={`input-field flex flex-col text-black ${className ?? ''} ${
@@ -82,7 +90,7 @@ const InputField = forwardRef<InputRef, InputFieldProps>(
                         type !== 'file' ? 'bg-[rgba(255,255,255,0.6)]' : ''
                      } placeholder-slate-500`}
                      type={type}
-                     id={id ?? generateID()}
+                     id={idState}
                      placeholder={placeholder}
                      name={name}
                      value={value}

--- a/src/components/book/verse/LoaderComponent.tsx
+++ b/src/components/book/verse/LoaderComponent.tsx
@@ -3,7 +3,7 @@ import useToastState from '@/hooks/useToastState'
 import { ColorRing } from 'react-loader-spinner'
 
 export default function LoaderComponent() {
-   const { toastState, turnToastOff } = useToastState()
+   const { toastState } = useToastState()
    const { type, visibility } = toastState
 
    return (

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -22,6 +22,7 @@ const store = configureStore({
                'coursesState/rescueChaptersState',
                'coursesState/rescueLessonsState',
                'coursesState/rescueLessonsCompletionState',
+               'modalState/changeModalState',
             ],
             ignoredPaths: [
                'coursesState.categories',
@@ -31,6 +32,7 @@ const store = configureStore({
                'coursesState.courses',
                'coursesState.chapters',
                'coursesState.lessonsCompletion',
+               'modalState.onClick',
             ],
          },
       }),

--- a/src/store/modalSlice/index.ts
+++ b/src/store/modalSlice/index.ts
@@ -17,7 +17,7 @@ const initialState: FunctionalModalObject = {
 }
 
 export const modalSlice = createSlice({
-   name: 'toastState',
+   name: 'modalState',
    initialState,
    reducers: {
       changeModalState: (state, { payload }: PayloadAction<FunctionalModalObject>) => {


### PR DESCRIPTION
Resolves #42 

Most error messages were eliminated with the exception of:

'''
The resource <URL> was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally.
'''

This error was discussed in [GitHub](https://github.com/vercel/next.js/discussions/49607) and it has to do with an issue within Next.js 13.4. So the socultion must come any time soon.